### PR TITLE
Rename deprecated Core_kernel to Core

### DIFF
--- a/lib/transformers/clip.ml
+++ b/lib/transformers/clip.ml
@@ -383,7 +383,7 @@ module Tokenizer = struct
     let s = Base.String.lowercase s in
     let matches = Re2.find_all t.re s in
     let matches =
-      Option.fold (Core_kernel.Or_error.ok matches) ~none:[] ~some:Base.Fn.id
+      Option.fold (Core.Or_error.ok matches) ~none:[] ~some:Base.Fn.id
     in
     let bpe_tokens = Base.List.map matches ~f:(bpe t) in
     let bpe_tokens = List.flatten bpe_tokens in


### PR DESCRIPTION
I tried compiling the project and ran into this issue. I believe Core_kernel is deprecated and has been removed in OCaml 5.0 (which I'm running).
Note that I didn't actually run it as I unfortunately lack the RAM/GPU to do so. I also didn't test this on OCaml 4.xx